### PR TITLE
update CMake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "extern/3DObjectTracking"]
-	path = extern/3DObjectTracking
-	url = git@github.com:DLR-RM/3DObjectTracking.git
-	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.11)
 project(pym3t LANGUAGES CXX)
 
 option(USE_AZURE_KINECT "Use Azure Kinect" OFF)
-option(USE_REALSENSE "Use RealSense D435" OFF)
+option(USE_REALSENSE "Use RealSense D435" ON)
 option(USE_GTEST "Use gtest" OFF)
 
 cmake_policy(SET CMP0148 OLD) # required for current pybind11
 
 # set(CMAKE_BUILD_TYPE "RELEASE") set(CMAKE_BUILD_TYPE "DEBUG")
 
-#set(CMAKE_CXX_STANDARD 17)
+# set(CMAKE_CXX_STANDARD 17)
 
 # We need libraries to be generated with Position Independent Code otherwise
 # compilation error in the pybind11 code set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
@@ -27,18 +27,18 @@ FetchContent_Declare(
   GIT_REPOSITORY "https://github.com/DLR-RM/3DObjectTracking.git"
   GIT_TAG "master"
   CMAKE_ARGS "-DUSE_AZURE_KINECT=${USE_AZURE_KINECT}"
-  "-DUSE_REALSENSE=${USE_REALSENSE}" "-DUSE_GTEST=${USE_GTEST}"
-  SOURCE_SUBDIR "M3T")
+  "-DUSE_REALSENSE=${USE_REALSENSE}" "-DUSE_GTEST=${USE_GTEST}" SOURCE_SUBDIR
+  "M3T")
 FetchContent_MakeAvailable(pybind11 m3t)
 
 # Create library for the extensions to m3t
 add_library(m3t_ext src/dummy_camera.cpp include/pym3t/dummy_camera.h)
 target_compile_features(m3t_ext PUBLIC cxx_std_17)
 target_include_directories(
-  m3t_ext PUBLIC $<INSTALL_INTERFACE:include>
-                 $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-                 $<BUILD_INTERFACE:${m3t_SOURCE_DIR}/include>
-                 )
+  m3t_ext
+  PUBLIC $<INSTALL_INTERFACE:include>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+         $<BUILD_INTERFACE:${m3t_SOURCE_DIR}/include>)
 target_link_libraries(m3t_ext PUBLIC m3t)
 
 pybind11_add_module(_pym3t_mod MODULE src/pym3t.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,6 @@ cmake_policy(SET CMP0148 OLD) # required for current pybind11
 
 # set(CMAKE_BUILD_TYPE "RELEASE") set(CMAKE_BUILD_TYPE "DEBUG")
 
-# set(CMAKE_CXX_STANDARD 17)
-
-# We need libraries to be generated with Position Independent Code otherwise
-# compilation error in the pybind11 code set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
-# -fPIC")
-
-# add_subdirectory(extern/3DObjectTracking/M3T)
-
 include(FetchContent)
 FetchContent_Declare(
   pybind11
@@ -26,9 +18,8 @@ FetchContent_Declare(
   m3t
   GIT_REPOSITORY "https://github.com/DLR-RM/3DObjectTracking.git"
   GIT_TAG "master"
-  CMAKE_ARGS "-DUSE_AZURE_KINECT=${USE_AZURE_KINECT}"
-  "-DUSE_REALSENSE=${USE_REALSENSE}" "-DUSE_GTEST=${USE_GTEST}" SOURCE_SUBDIR
-  "M3T")
+  SOURCE_SUBDIR "M3T" CMAKE_ARGS "-DUSE_AZURE_KINECT=${USE_AZURE_KINECT}"
+  "-DUSE_REALSENSE=${USE_REALSENSE}" "-DUSE_GTEST=${USE_GTEST}")
 FetchContent_MakeAvailable(pybind11 m3t)
 
 # Create library for the extensions to m3t

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,50 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(pym3t LANGUAGES CXX)
 
-find_package(pybind11 CONFIG REQUIRED)
-
 option(USE_AZURE_KINECT "Use Azure Kinect" OFF)
-option(USE_REALSENSE "Use RealSense D435" ON)
+option(USE_REALSENSE "Use RealSense D435" OFF)
 option(USE_GTEST "Use gtest" OFF)
 
-set(CMAKE_BUILD_TYPE "RELEASE")
-# set(CMAKE_BUILD_TYPE "DEBUG")
+cmake_policy(SET CMP0148 OLD) # required for current pybind11
 
-set(CMAKE_CXX_STANDARD 17)
+# set(CMAKE_BUILD_TYPE "RELEASE") set(CMAKE_BUILD_TYPE "DEBUG")
 
-# We need libraries to be generated with Position Independent Code
-# otherwise compilation error in the pybind11 code
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+#set(CMAKE_CXX_STANDARD 17)
 
-add_subdirectory(extern/3DObjectTracking/M3T)
+# We need libraries to be generated with Position Independent Code otherwise
+# compilation error in the pybind11 code set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}
+# -fPIC")
+
+# add_subdirectory(extern/3DObjectTracking/M3T)
+
+include(FetchContent)
+FetchContent_Declare(
+  pybind11
+  GIT_REPOSITORY "https://github.com/pybind/pybind11"
+  GIT_TAG "v2.11.1")
+FetchContent_Declare(
+  m3t
+  GIT_REPOSITORY "https://github.com/DLR-RM/3DObjectTracking.git"
+  GIT_TAG "master"
+  CMAKE_ARGS "-DUSE_AZURE_KINECT=${USE_AZURE_KINECT}"
+  "-DUSE_REALSENSE=${USE_REALSENSE}" "-DUSE_GTEST=${USE_GTEST}"
+  SOURCE_SUBDIR "M3T")
+FetchContent_MakeAvailable(pybind11 m3t)
 
 # Create library for the extensions to m3t
-add_library(m3t_ext src/dummy_camera.cpp)
-target_include_directories(m3t_ext PUBLIC include)
+add_library(m3t_ext src/dummy_camera.cpp include/pym3t/dummy_camera.h)
+target_compile_features(m3t_ext PUBLIC cxx_std_17)
+target_include_directories(
+  m3t_ext PUBLIC $<INSTALL_INTERFACE:include>
+                 $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+                 $<BUILD_INTERFACE:${m3t_SOURCE_DIR}/include>
+                 )
 target_link_libraries(m3t_ext PUBLIC m3t)
 
 pybind11_add_module(_pym3t_mod MODULE src/pym3t.cpp)
-target_link_libraries(_pym3t_mod PUBLIC m3t)
 target_link_libraries(_pym3t_mod PUBLIC m3t_ext)
-target_compile_features(_pym3t_mod PUBLIC cxx_std_17)
-target_include_directories(_pym3t_mod PUBLIC include)
+target_include_directories(
+  _pym3t_mod PUBLIC $<INSTALL_INTERFACE:include>
+                    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
 
 install(TARGETS _pym3t_mod DESTINATION pym3t)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,9 @@ project(pym3t LANGUAGES CXX)
 
 find_package(pybind11 CONFIG REQUIRED)
 
-# TODO: find a way to pass these options as command line arguments
-set(USE_AZURE_KINECT OFF CACHE BOOL "Use Azure Kinect")
-set(USE_REALSENSE ON CACHE BOOL "Use RealSense D435")
-set(USE_GTEST OFF CACHE BOOL "Use gtest")
+option(USE_AZURE_KINECT "Use Azure Kinect" OFF)
+option(USE_REALSENSE "Use RealSense D435" ON)
+option(USE_GTEST "Use gtest" OFF)
 
 set(CMAKE_BUILD_TYPE "RELEASE")
 # set(CMAKE_BUILD_TYPE "DEBUG")
@@ -14,7 +13,7 @@ set(CMAKE_BUILD_TYPE "RELEASE")
 set(CMAKE_CXX_STANDARD 17)
 
 # We need libraries to be generated with Position Independent Code
-# otherwise compilation error in the pybind11 code 
+# otherwise compilation error in the pybind11 code
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_subdirectory(extern/3DObjectTracking/M3T)

--- a/include/pym3t/dummy_camera.h
+++ b/include/pym3t/dummy_camera.h
@@ -2,7 +2,7 @@
 #ifndef M3t_INCLUDE_M3t_dummy_camera_H_
 #define M3t_INCLUDE_M3t_dummy_camera_H_
 
-#include <filesystem/filesystem.h>
+#include <filesystem>
 #include <m3t/camera.h>
 #include <m3t/common.h>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # build time dependencies, installed in an isolated environment
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core"]
 # use scikit-build instead of setuptools
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
- use CMake to get M3T instead of git submodule
- use CMake to get pybind11 instead of pip
- use `option()` for kinect / realsense / gtest, to allow eg. `cmake -DUSE_REALSENSE=ON` or `cmake -DUSE_REALSENSE=OFF`
- remove `CMAKE_CXX_STANDARD`: we want *at least* 17, so don't require exactly 17. use `cxx_std_17` instead, ref. https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html#requiring-language-standards
- remove `CMAKE_BUILD_TYPE` to allow users specify themselves eg. `cmake -DCMAKE_BUILD_TYPE=Debug` or `export CMAKE_BUILD_TYPE=RelWithDebInfo`
- remove `-fPIC`, as it looks like it is not necessary.

A better solution would be to make CMake look for M3T & pybind11, and fetch those only if they are not found. It would allow downstream package managers to provide their own versions and avoid dynamic downloads at configure time.