### PR TITLE
Add option to build pacake without realsense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,17 @@ cmake_minimum_required(VERSION 3.11)
 project(pym3t LANGUAGES CXX)
 
 option(USE_AZURE_KINECT "Use Azure Kinect" OFF)
-option(USE_REALSENSE "Use RealSense D435" ON)
+option(USE_REALSENSE "Use RealSense D435" OFF)
 option(USE_GTEST "Use gtest" OFF)
 
 cmake_policy(SET CMP0148 OLD) # required for current pybind11
 
 # set(CMAKE_BUILD_TYPE "RELEASE") set(CMAKE_BUILD_TYPE "DEBUG")
+
+IF(USE_REALSENSE)
+  ADD_DEFINITIONS(-DPYM3T_WITH_REALSENSE)
+  LIST(APPEND CFLAGS_DEPENDENCIES "-DPYM3T_WITH_REALSENSE")
+ENDIF(USE_REALSENSE)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@ A python wrapper around M3T tracker from https://github.com/DLR-RM/3DObjectTrack
 
 # Installation
 
-`git clone git@github.com:MedericFourmy/pym3t.git --recursive`
+```
+git clone https://github.com/agimus-project/pym3t.git
+cd pym3t
+conda env create --name pym3t --file environment.yaml
+conda activate pym3t
+pip install .
+```
 
-Install dependencies with conda:  
-`conda env create --name pym3t --file environment.yaml`  
+## Install with Realsense support
+PYM3T by defult builds without Intel Realsense support. To enable it first install librealsense following the [official guide](https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md#installing-the-packages).
 
-Then  
-`pip install .`
+Nex build the package with a following command:
+```
+# TODO instruct on how to pass CMake flags
+pip install . 
+```
 
 # Example scripts
 As example of usage of the library, scripts are provided: 

--- a/src/pym3t.cpp
+++ b/src/pym3t.cpp
@@ -14,7 +14,11 @@
 // M3T
 #include <m3t/common.h>
 #include <m3t/camera.h>
+
+#ifdef PYM3T_WITH_REALSENSE
 #include <m3t/realsense_camera.h>
+#endif
+
 #include <m3t/renderer_geometry.h>
 #include <m3t/basic_depth_renderer.h>
 #include <m3t/silhouette_renderer.h>
@@ -37,13 +41,6 @@ namespace py = pybind11;
 using namespace pybind11::literals;  // to use "arg"_a shorthand
 using namespace m3t;
 using namespace Eigen;
-
-/**
- * TODO: 
- * - Read the flag USE_REALSENSE to decide whether or not to create bindings
- * */ 
-
-
 
 PYBIND11_MODULE(_pym3t_mod, m) {
 
@@ -119,6 +116,7 @@ PYBIND11_MODULE(_pym3t_mod, m) {
     // DepthCamera -> not constructible, just to enable automatic downcasting and binding of child classes
     py::class_<DepthCamera, Camera, std::shared_ptr<DepthCamera>>(m, "DepthCamera");
 
+#ifdef PYM3T_WITH_REALSENSE
     // RealSenseColorCamera
     py::class_<RealSenseColorCamera, ColorCamera, std::shared_ptr<RealSenseColorCamera>>(m, "RealSenseColorCamera")
         .def(py::init<const std::string &, bool>(), "name"_a, "use_depth_as_world_frame"_a=false)
@@ -128,6 +126,7 @@ PYBIND11_MODULE(_pym3t_mod, m) {
     py::class_<RealSenseDepthCamera, DepthCamera, std::shared_ptr<RealSenseDepthCamera>>(m, "RealSenseDepthCamera")
         .def(py::init<const std::string &, bool>(), "name"_a, "use_color_as_world_frame"_a=true)
         ;
+#endif
 
     // DummyColorCamera
     py::class_<DummyColorCamera, ColorCamera, std::shared_ptr<DummyColorCamera>>(m, "DummyColorCamera")
@@ -443,5 +442,13 @@ PYBIND11_MODULE(_pym3t_mod, m) {
         .def_property("tikhonov_parameter_rotation", &Optimizer::tikhonov_parameter_rotation, &Optimizer::set_tikhonov_parameter_rotation)
         .def_property("tikhonov_parameter_translation", &Optimizer::tikhonov_parameter_translation, &Optimizer::set_tikhonov_parameter_translation)
         ;
+
+    // Constants
+    m.attr("WITH_REALSENSE") = 
+#ifdef PYM3T_WITH_REALSENSE
+      py::bool_(true);
+#else
+      py::bool_(false);
+#endif
 
 }

--- a/src/pym3t/__init__.py
+++ b/src/pym3t/__init__.py
@@ -1,6 +1,5 @@
 from ._pym3t_mod import Tracker
 from ._pym3t_mod import RendererGeometry
-from ._pym3t_mod import RealSenseColorCamera, RealSenseDepthCamera
 from ._pym3t_mod import Intrinsics, IDType
 from ._pym3t_mod import DummyColorCamera, DummyDepthCamera
 from ._pym3t_mod import NormalColorViewer, NormalDepthViewer
@@ -10,10 +9,13 @@ from ._pym3t_mod import StaticDetector
 from ._pym3t_mod import RegionModel, DepthModel
 from ._pym3t_mod import RegionModality, DepthModality, TextureModality
 from ._pym3t_mod import Optimizer
+from ._pym3t_mod import WITH_REALSENSE
+
+if WITH_REALSENSE:
+    from ._pym3t_mod import RealSenseColorCamera, RealSenseDepthCamera
 
 __all__ = ['Tracker', 
-           'RendererGeometry', 
-           'RealSenseColorCamera', 'RealSenseDepthCamera', 
+           'RendererGeometry',
            'Intrinsics', 'IDType',
            'DummyColorCamera', 'DummyDepthCamera', 
            'NormalColorViewer', 'NormalDepthViewer', 
@@ -23,3 +25,6 @@ __all__ = ['Tracker',
            'RegionModel', 'DepthModel', 
            'RegionModality', 'DepthModality', 'TextureModality' 
            'Optimizer',] 
+
+if WITH_REALSENSE:
+    __all__.append(['RealSenseColorCamera', 'RealSenseDepthCamera'])


### PR DESCRIPTION
Currently, this is a draft PR, as I not sure how to expose CMake flags to command line.
I am also unsure if in `__init__.py` there should be a single `if` statement importing the realsense modules and appending them to the `__all__` list, or should it stay like this.

Another open question is if this change bumps the package version from `0.0.1` to `0.0.2` or not, as it directly modifies API and dependencies?