### PR TITLE
Fix/opencv version optional deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.15)
 project(pym3t LANGUAGES CXX)
 
 option(USE_AZURE_KINECT "Use Azure Kinect" OFF)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cd pym3t
 python -m venv .venv
 source .venv/bin/activate
 pip install .
+# or if you want to run examples
+pip install .[examples]
 ```
 
 # Example scripts

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,17 +1,18 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python>=3.8
   - compilers
   - cmake
   - scikit-build
   - pyyaml
-  - opencv
+  - opencv==4.3.0
   - mesa-libgl-devel-cos7-x86_64 
   - mesa-dri-drivers-cos7-x86_64 
   - libxcb
   - glew
   - glfw
   - librealsense
-  - quaternion
   - eigen
+  - numpy
+  - quaternion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,13 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "pym3t"
 version = "0.0.1"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 # run time dependencies
-dependencies = [
-    "numpy"
+dependencies = []
+
+[project.optional-dependencies]
+examples = [
+    "numpy<2.0.0", # older numpy-quaternion releases are not compatible with numpy 2.0.0
+    "numpy-quaternion>=2023.0.3",
+    "opencv-python>=4.11.0.86",
 ]


### PR DESCRIPTION
- add optional dependencies to run examples
- fix opencv version as it is hardcoded in https://github.com/DLR-RM/3DObjectTracking/blob/f02106186a1e756450226b3b793e309506817c58/M3T/CMakeLists.txt#L36

The opencv version requirements should be relaxed in the `3DObjectTracking` make it compatible with more recent python/opencv versions.